### PR TITLE
Optimize spec version display

### DIFF
--- a/app/components/RoleTable.tsx
+++ b/app/components/RoleTable.tsx
@@ -72,6 +72,7 @@ export default function RoleTable({ roles }: RoleTableProps) {
                     <TableRow>
                         <TableHeader>Role</TableHeader>
                         <TableHeader>Signing Starts</TableHeader>
+                        <TableHeader>Version</TableHeader>
                         <TableHeader>Expires</TableHeader>
                         <TableHeader>Signers</TableHeader>
                     </TableRow>
@@ -83,6 +84,7 @@ export default function RoleTable({ roles }: RoleTableProps) {
                                 {role.role} (<Link href={role.jsonLink} target="_blank">json</Link>)
                             </TableCell>
                             <TableCell>{role.signingStarts || 'N/A'}</TableCell>
+                            <TableCell>{role.version || '-'}</TableCell>
                             <TableCell>{role.expires}</TableCell>
                             <TableCell>
                                 {role.signers.keyids.length > 0 ? (

--- a/app/components/TufViewerClient.tsx
+++ b/app/components/TufViewerClient.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import RoleTable from './RoleTable';
 import RepoInfo from './RepoInfo';
+import { RoleInfo } from '../utils/types';
 
 interface TufViewerClientProps {
     roles: RoleInfo[];
@@ -40,14 +41,21 @@ export default function TufViewerClient({ roles, version, error }: TufViewerClie
         );
     }
 
+    // Get spec_version from the first role (assuming it's the same for all)
+    const specVersion = roles[0]?.specVersion;
+
     return (
-        <main style={{ padding: '1rem' }}>
-            <h2>Repository State</h2>
+        <div className="space-y-4">
+            {specVersion && (
+                <div className="text-sm text-gray-600">
+                    TUF Specification Version: {specVersion}
+                </div>
+            )}
             <RoleTable roles={roles} />
             <RepoInfo
                 lastUpdated={new Date().toUTCString()}
                 toolVersion={version}
             />
-        </main>
+        </div>
     );
 } 

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -100,4 +100,6 @@ export interface RoleInfo {
         keyids: string[];
     };
     jsonLink: string;
+    version?: number;
+    specVersion?: string;
 } 


### PR DESCRIPTION
Move spec_version display above role table to avoid repetition in each row.

fixes #13

![image](https://github.com/user-attachments/assets/9b04a1d9-b66d-4ff8-8d2f-267e92f9baba)

