### PR TITLE
Enhance UI: Add GitHub Link, Example TUF URLs, and Improve Color Scheme

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -2,8 +2,9 @@
 
 import React from 'react';
 import { GlobalStyle } from './styles/global';
-import { Header, Container, Title, Footer } from './styles/components';
+import { Header, Container, Title, Footer, GitHubLink, HeaderContent } from './styles/components';
 import StyledComponentsRegistry from './registry';
+import { FaGithub } from 'react-icons/fa';
 
 export default function ClientLayout({
     children,
@@ -15,7 +16,17 @@ export default function ClientLayout({
             <GlobalStyle />
             <Header>
                 <Container>
-                    <Title>TUF Repository Viewer</Title>
+                    <HeaderContent>
+                        <Title>TUF Repository Viewer</Title>
+                        <GitHubLink 
+                            href="https://github.com/DeshDeepakKant/TUF-Metadata-Visualizer"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label="View source code on GitHub"
+                        >
+                            <FaGithub />
+                        </GitHubLink>
+                    </HeaderContent>
                 </Container>
             </Header>
             <Container>

--- a/app/components/ExampleUrls.tsx
+++ b/app/components/ExampleUrls.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import React from 'react';
+import { 
+    ExampleUrlsContainer, 
+    ExampleUrlsTitle, 
+    ExampleUrlsList, 
+    ExampleUrlItem, 
+    ExampleUrlLink,
+    ExampleUrlDescription 
+} from '../styles/components';
+
+interface ExampleUrlsProps {
+    onUrlClick: (url: string) => void;
+}
+
+export default function ExampleUrls({ onUrlClick }: ExampleUrlsProps) {
+    const examples = [
+        {
+            url: 'https://jku.github.io/tuf-demo/metadata/',
+            description: 'TUF Demo Repository'
+        },
+        {
+            url: 'https://tuf-repo-cdn.sigstore.dev/',
+            description: 'Sigstore TUF Repository'
+        }
+    ];
+
+    return (
+        <ExampleUrlsContainer>
+            <ExampleUrlsTitle>Example TUF Repositories</ExampleUrlsTitle>
+            <ExampleUrlsList>
+                {examples.map((example, index) => (
+                    <ExampleUrlItem
+                        key={index}
+                        tabIndex={0}
+                        role="button"
+                        aria-label={`Visualize ${example.description}`}
+                        onClick={() => onUrlClick(example.url)}
+                        onKeyDown={e => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                onUrlClick(example.url);
+                            }
+                        }}
+                    >
+                        <ExampleUrlDescription>
+                            {example.description}:
+                        </ExampleUrlDescription>
+                        <ExampleUrlLink as="span">
+                            {example.url}
+                        </ExampleUrlLink>
+                    </ExampleUrlItem>
+                ))}
+            </ExampleUrlsList>
+        </ExampleUrlsContainer>
+    );
+} 

--- a/app/components/RoleTable.tsx
+++ b/app/components/RoleTable.tsx
@@ -56,11 +56,14 @@ const ExpandButton = styled.button<{ $expanded?: boolean }>`
   font-size: 0.75rem;
   margin-right: 0.5rem;
   padding: 0.25rem;
+  color: #fff;
   transform: ${props => props.$expanded ? 'rotate(90deg)' : 'rotate(0)'};
   transition: transform 0.2s ease;
 `;
 
-
+const ClickableTableRow = styled(TableRow)<{ $expandable?: boolean }>`
+  ${props => props.$expandable ? 'cursor: pointer;' : ''}
+`;
 
 interface RoleTableProps {
     roles: RoleInfo[];
@@ -153,12 +156,28 @@ export default function RoleTable({ roles }: RoleTableProps) {
                 <tbody>
                     {roles.map((role) => (
                         <React.Fragment key={role.role}>
-                            <TableRow>
+                            <ClickableTableRow
+                                $expandable={hasExpandableContent(role)}
+                                onClick={hasExpandableContent(role) ? (e => {
+                                    // Prevent row expand if clicking a link
+                                    if ((e.target as HTMLElement).closest('a')) return;
+                                    handleRowExpand(role.role);
+                                }) : undefined}
+                                tabIndex={hasExpandableContent(role) ? 0 : undefined}
+                                onKeyDown={hasExpandableContent(role) ? (e => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        handleRowExpand(role.role);
+                                    }
+                                }) : undefined}
+                            >
                                 <TableCell>
                                     {hasExpandableContent(role) && (
                                         <ExpandButton
                                             $expanded={expandedRow === role.role}
-                                            onClick={() => handleRowExpand(role.role)}
+                                            onClick={e => {
+                                                e.stopPropagation();
+                                                handleRowExpand(role.role);
+                                            }}
                                         >
                                             ▶
                                         </ExpandButton>
@@ -205,7 +224,7 @@ export default function RoleTable({ roles }: RoleTableProps) {
                                         </SignerInfo>
                                     )}
                                 </TableCell>
-                            </TableRow>
+                            </ClickableTableRow>
 
                             {/* Show targets content for any role with targets data when expanded */}
                             {role.targets && Object.keys(role.targets).length > 0 && expandedRow === role.role && (

--- a/app/styles/components.ts
+++ b/app/styles/components.ts
@@ -142,4 +142,59 @@ export const HeaderContent = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
+`;
+
+export const ExampleUrlsContainer = styled.div`
+  margin-top: 2rem;
+  padding: 1.5rem;
+  background-color: var(--header);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+`;
+
+export const ExampleUrlsTitle = styled.h3`
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: var(--text);
+`;
+
+export const ExampleUrlsList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+export const ExampleUrlItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background-color: var(--background);
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  transition: all 0.2s ease;
+  flex-wrap: wrap;
+  cursor: pointer;
+  outline: none;
+
+  &:hover, &:focus {
+    background-color: var(--hover);
+    border-color: var(--primary);
+    box-shadow: 0 0 0 2px var(--primary);
+  }
+`;
+
+export const ExampleUrlLink = styled.span`
+  color: var(--link);
+  font-family: monospace;
+  font-size: 0.9rem;
+  word-break: break-all;
+`;
+
+export const ExampleUrlDescription = styled.span`
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
 `; 

--- a/app/styles/components.ts
+++ b/app/styles/components.ts
@@ -116,4 +116,30 @@ export const SignersList = styled.div`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+`;
+
+export const GitHubLink = styled.a`
+  display: flex;
+  align-items: center;
+  color: var(--text);
+  text-decoration: none;
+  margin-left: auto;
+  padding: 0.5rem;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: var(--hover);
+  }
+
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+`;
+
+export const HeaderContent = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
 `; 


### PR DESCRIPTION
This PR improves the usability and visual appeal of the TUF Metadata Visualizer by:
- Adding a GitHub repository link with icon to the navigation bar for easy access to the source code.
- Displaying example TUF repository URLs on the main page to help users get started quickly.
- Updating the color scheme for better readability, including making expand buttons and dropdowns more visible.
- Making table rows expandable by clicking anywhere on the row, not just the expand button.